### PR TITLE
Fix branch name in example.yaml

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -26,7 +26,7 @@ esphome:
   board: $board
 
 external_components:
-  - source: github://juaigl/esphome-garage-cover-single-control@main
+  - source: github://juaigl/esphome-garage-cover-single-control@master
 
 wifi:
   # replace by your own data


### PR DESCRIPTION
Example was pointint to "main" instead of "master"